### PR TITLE
fix: use relative path to open questions.json

### DIFF
--- a/desktop_app/quiz.py
+++ b/desktop_app/quiz.py
@@ -51,8 +51,7 @@ def load_questions(file_path):
 
 def main():
     # Get the current directory of the script
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    file_path = os.path.join(current_dir, 'questions.json')
+    file_path = './questions.json'
     questions = load_questions(file_path)
     random.shuffle(questions)
     


### PR DESCRIPTION
You need to use a relative path to open the file questions.json in order to load all the questions